### PR TITLE
feat(modules): external modules upgrade 20250910

### DIFF
--- a/modules/base/README.md
+++ b/modules/base/README.md
@@ -27,7 +27,7 @@ This layer includes the following GoCloud wrapper modules:
 ```hcl
 module "base" {
   source = "gocloudLa/standard-platform/aws//modules/base"
-  version = "1.0.0"
+  # version = "{tag_specific_version}"
 
   metadata = local.metadata
 

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -1,6 +1,6 @@
 module "wrapper_vpc" {
   source  = "gocloudLa/wrapper-vpc/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 

--- a/modules/foundation/README.md
+++ b/modules/foundation/README.md
@@ -33,7 +33,7 @@ This layer includes the following GoCloud wrapper modules:
 ```hcl
 module "foundation" {
   source = "gocloudLa/standard-platform/aws//modules/foundation"
-  version = "1.0.0"
+  # version = "{tag_specific_version}"
 
   metadata = local.metadata
 

--- a/modules/foundation/main.tf
+++ b/modules/foundation/main.tf
@@ -1,6 +1,6 @@
 module "wrapper_acm" {
   source  = "gocloudLa/wrapper-acm/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 
@@ -14,7 +14,7 @@ module "wrapper_acm" {
 
 module "wrapper_gitlab_runner" {
   source  = "gocloudLa/wrapper-gitlab-runner/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 
@@ -68,7 +68,7 @@ module "wrapper_route53" {
 
 module "wrapper_service_scheduler" {
   source  = "gocloudLa/wrapper-service-scheduler/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 

--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -26,7 +26,7 @@ This layer includes the following GoCloud wrapper modules:
 ```hcl
 module "organization" {
   source = "gocloudLa/standard-platform/aws//modules/organization"
-  version = "1.0.0"
+  # version = "{tag_specific_version}"
 
   metadata = local.metadata
 

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -21,7 +21,7 @@ module "wrapper_identity_center" {
 
 module "wrapper_s3_backend" {
   source  = "gocloudLa/wrapper-s3-backend/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 

--- a/modules/project/README.md
+++ b/modules/project/README.md
@@ -35,7 +35,7 @@ This layer includes the following GoCloud wrapper modules:
 ```hcl
 module "project" {
   source = "gocloudLa/standard-platform/aws//modules/project"
-  version = "1.0.0"
+  # version = "{tag_specific_version}"
 
   metadata = local.metadata
 

--- a/modules/workload/README.md
+++ b/modules/workload/README.md
@@ -27,7 +27,7 @@ This layer includes the following GoCloud wrapper modules:
 ```hcl
 module "workload" {
   source = "gocloudLa/standard-platform/aws//modules/workload"
-  version = "1.0.0"
+  # version = "{tag_specific_version}"
 
   metadata = local.metadata
 

--- a/modules/workload/main.tf
+++ b/modules/workload/main.tf
@@ -1,6 +1,6 @@
 module "wrapper_static_site" {
   source  = "gocloudLa/wrapper-static-site/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 
@@ -14,7 +14,7 @@ module "wrapper_static_site" {
 
 module "wrapper_ecs_service" {
   source  = "gocloudLa/wrapper-ecs-service/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 
@@ -25,7 +25,7 @@ module "wrapper_ecs_service" {
 
 module "wrapper_batch_job" {
   source  = "gocloudLa/wrapper-batch-job/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   metadata = var.metadata
 


### PR DESCRIPTION
- terraform-aws-wrapper-ecs-service (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-vpc (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-service-scheduler (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-s3-backend (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-gitlab-runner (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-batch-job (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-acm (1.0.0 -> 1.0.1)
- terraform-aws-wrapper-static-site (1.0.0 -> 1.0.1)